### PR TITLE
Attempt to fix "repeat"

### DIFF
--- a/addons/CheatCoder/CheatCodeListener.gd
+++ b/addons/CheatCoder/CheatCodeListener.gd
@@ -45,9 +45,7 @@ func _input(event: InputEvent) -> void:
 				timeout_timer = timeout_delay
 				
 				if code_progress == len(code.entries):
-					if not repeat and not first_time:
-						emit_signal("cheat_activated")
-					if repeat:
+					if repeat or not first_time:
 						emit_signal("cheat_activated")
 					first_time = true
 					code_progress = 0

--- a/addons/CheatCoder/CheatCodeListener.gd
+++ b/addons/CheatCoder/CheatCodeListener.gd
@@ -47,6 +47,8 @@ func _input(event: InputEvent) -> void:
 				if code_progress == len(code.entries):
 					if not repeat and not first_time:
 						emit_signal("cheat_activated")
+					if repeat:
+						emit_signal("cheat_activated")
 					first_time = true
 					code_progress = 0
 				else:


### PR DESCRIPTION
When `repeat` is true, cheat fails to activate (signal is not emitted).

Added two lines of code to CheatCodeListener.gd and it seems to have worked.

I'm an absolute noob at scripting, pls review before merging.